### PR TITLE
Fix CSV import header normalization

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,3 @@
-import type { NextConfig } from "next";
-
 const nextConfig = {
   eslint: {
     // 🚀 本番ビルド時に ESLint エラーで失敗しない（暫定）


### PR DESCRIPTION
## Summary
- parse uploaded CSV files as raw rows to support blank or duplicated header labels
- provide stable column identifiers with fallback names so mapping, preview, and payload generation work for tabular exports
- deduplicate combined tag values and reset mappings after each upload while keeping the Next.js config lint-clean

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e596ccdd388323be3e79f214f0c9fb