### PR TITLE
Enhance CSV import flexibility and dashboard navigation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,3 @@
-import type { NextConfig } from "next";
-
 const nextConfig = {
   eslint: {
     // 🚀 本番ビルド時に ESLint エラーで失敗しない（暫定）

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,19 @@ model Evangelist {
   lastName     String?
   email        String?  @unique
   contactPref  String?  // 連絡手段の希望
+  supportPriority String?
+  pattern       String?
+  meetingStatus String?
+  registrationStatus String?
+  lineRegistered String?
+  phoneNumber  String?
+  acquisitionSource String?
+  facebookUrl  String?
+  listAcquired String?
+  matchingListUrl String?
+  contactOwner String?
+  marketingContactStatus String?
+  sourceCreatedAt DateTime?
   strengths    String?  // 強み・専門分野（初回面談で入力）
   notes        String?  // 備考
   tier         Tier     @default(TIER2)

--- a/src/app/api/evangelists/import/route.ts
+++ b/src/app/api/evangelists/import/route.ts
@@ -40,41 +40,116 @@ export async function POST(req: NextRequest) {
       lastName?: string
       email?: string
       contactPref?: string
+      supportPriority?: string
+      pattern?: string
+      meetingStatus?: string
+      registrationStatus?: string
+      lineRegistered?: string
+      phoneNumber?: string
+      acquisitionSource?: string
+      facebookUrl?: string
+      listAcquired?: string
+      matchingListUrl?: string
+      contactOwner?: string
+      marketingContactStatus?: string
+      sourceCreatedAt?: string
       strengths?: string
       notes?: string
       tier?: string
       tags?: string[] | string
     }
 
-    const ops = rows.map((r: ImportRow) =>
-      prisma.evangelist.upsert({
-        where: { email: r.email ?? "__no_email__" }, // email優先
-        create: {
-          recordId: r.recordId || null,
-          firstName: r.firstName || null,
-          lastName: r.lastName || null,
-          email: r.email || null,
-          contactPref: r.contactPref || null,
-          strengths: r.strengths || null,
-          notes: r.notes || null,
-          tier: (r.tier as 'TIER1' | 'TIER2') || "TIER2",
-          tags: Array.isArray(r.tags) ? JSON.stringify(r.tags) : (r.tags ? JSON.stringify([r.tags]) : null),
-          assignedCsId: user.role === 'CS' ? user.userId : null,
-        },
-        update: {
-          recordId: r.recordId || undefined,
-          firstName: r.firstName || undefined,
-          lastName: r.lastName || undefined,
-          contactPref: r.contactPref || undefined,
-          strengths: r.strengths || undefined,
-          notes: r.notes || undefined,
-          tier: (r.tier as 'TIER1' | 'TIER2') || undefined,
-          tags: Array.isArray(r.tags) ? JSON.stringify(r.tags) : (r.tags ? JSON.stringify([r.tags]) : undefined),
-        }
-      })
-    );
+    const parseSourceCreatedAt = (value?: string | null) => {
+      if (!value) return null;
+      const normalized = value.replace(/\//g, '-').replace(' ', 'T');
+      const date = new Date(normalized);
+      if (Number.isNaN(date.getTime())) {
+        return null;
+      }
+      return date;
+    };
 
-    await prisma.$transaction(ops);
+    const buildCreateData = (r: ImportRow) => ({
+      recordId: r.recordId || null,
+      firstName: r.firstName || null,
+      lastName: r.lastName || null,
+      email: r.email || null,
+      contactPref: r.contactPref || null,
+      supportPriority: r.supportPriority || null,
+      pattern: r.pattern || null,
+      meetingStatus: r.meetingStatus || null,
+      registrationStatus: r.registrationStatus || null,
+      lineRegistered: r.lineRegistered || null,
+      phoneNumber: r.phoneNumber || null,
+      acquisitionSource: r.acquisitionSource || null,
+      facebookUrl: r.facebookUrl || null,
+      listAcquired: r.listAcquired || null,
+      matchingListUrl: r.matchingListUrl || null,
+      contactOwner: r.contactOwner || null,
+      marketingContactStatus: r.marketingContactStatus || null,
+      sourceCreatedAt: parseSourceCreatedAt(r.sourceCreatedAt) || null,
+      strengths: r.strengths || null,
+      notes: r.notes || null,
+      tier: (r.tier as 'TIER1' | 'TIER2') || "TIER2",
+      tags: Array.isArray(r.tags) ? JSON.stringify(r.tags) : (r.tags ? JSON.stringify([r.tags]) : null),
+      assignedCsId: user.role === 'CS' ? user.userId : null,
+    });
+
+    const buildUpdateData = (r: ImportRow) => ({
+      recordId: r.recordId || undefined,
+      firstName: r.firstName || undefined,
+      lastName: r.lastName || undefined,
+      contactPref: r.contactPref || undefined,
+      supportPriority: r.supportPriority || undefined,
+      pattern: r.pattern || undefined,
+      meetingStatus: r.meetingStatus || undefined,
+      registrationStatus: r.registrationStatus || undefined,
+      lineRegistered: r.lineRegistered || undefined,
+      phoneNumber: r.phoneNumber || undefined,
+      acquisitionSource: r.acquisitionSource || undefined,
+      facebookUrl: r.facebookUrl || undefined,
+      listAcquired: r.listAcquired || undefined,
+      matchingListUrl: r.matchingListUrl || undefined,
+      contactOwner: r.contactOwner || undefined,
+      marketingContactStatus: r.marketingContactStatus || undefined,
+      sourceCreatedAt: parseSourceCreatedAt(r.sourceCreatedAt) || undefined,
+      strengths: r.strengths || undefined,
+      notes: r.notes || undefined,
+      tier: (r.tier as 'TIER1' | 'TIER2') || undefined,
+      tags: Array.isArray(r.tags) ? JSON.stringify(r.tags) : (r.tags ? JSON.stringify([r.tags]) : undefined),
+    });
+
+    const operations = rows.reduce((acc, row: ImportRow) => {
+      const createData = buildCreateData(row);
+      const updateData = buildUpdateData(row);
+
+      if (row.recordId) {
+        acc.push(
+          prisma.evangelist.upsert({
+            where: { recordId: row.recordId },
+            create: createData,
+            update: updateData,
+          })
+        );
+        return acc;
+      }
+
+      if (row.email) {
+        acc.push(
+          prisma.evangelist.upsert({
+            where: { email: row.email },
+            create: createData,
+            update: updateData,
+          })
+        );
+        return acc;
+      }
+
+      acc.push(prisma.evangelist.create({ data: createData }));
+      return acc;
+    }, [] as Promise<unknown>[]);
+
+    await prisma.$transaction(operations);
     return NextResponse.json({ ok: true, count: rows.length });
   } catch (error) {
     console.error('CSV import error:', error);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,16 +34,26 @@ export default function DashboardPage() {
     const fetchUserAndStats = async () => {
       try {
         // ユーザー情報を取得
-        const userResponse = await fetch('/api/auth/me');
+        const userResponse = await fetch('/api/auth/me', {
+          credentials: 'include',
+          cache: 'no-store',
+        });
         if (!userResponse.ok) {
           router.push('/login');
           return;
         }
-        const userData = await userResponse.json();
-        setUser(userData);
+        const userPayload: { user?: User } = await userResponse.json();
+        if (!userPayload.user) {
+          router.push('/login');
+          return;
+        }
+        setUser(userPayload.user);
 
         // ダッシュボード統計を取得
-        const statsResponse = await fetch('/api/dashboard/stats');
+        const statsResponse = await fetch('/api/dashboard/stats', {
+          credentials: 'include',
+          cache: 'no-store',
+        });
         if (statsResponse.ok) {
           const statsData = await statsResponse.json();
           setStats(statsData);
@@ -89,14 +99,17 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto px-4 py-8 text-white">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">
+        <h1 className="text-3xl font-bold mb-2">
           ダッシュボード
         </h1>
-        <p className="text-gray-600">
-          こんにちは、{user.name}さん ({user.role === 'ADMIN' ? '管理者' : 'CS'})
-        </p>
+        <div className="flex items-center gap-2 text-sm opacity-90">
+          <span>こんにちは、{user.name}さん</span>
+          <Badge variant="secondary" className="bg-white/20 text-white">
+            {user.role === 'ADMIN' ? '管理者' : 'CS'}
+          </Badge>
+        </div>
       </div>
 
       {/* 統計カード */}

--- a/src/components/CSVMapper.tsx
+++ b/src/components/CSVMapper.tsx
@@ -1,64 +1,134 @@
 'use client';
 import Papa from 'papaparse';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
+import { UploadCloud, ListChecks, Table as TableIcon } from 'lucide-react';
 
 const DB_FIELDS = [
-  { key: 'recordId', label: 'Record ID' },
+  { key: 'recordId', label: 'レコードID' },
   { key: 'firstName', label: '名' },
   { key: 'lastName', label: '姓' },
-  { key: 'email', label: 'Email' },
-  { key: 'contactPref', label: '連絡方法' },
+  { key: 'supportPriority', label: 'サポート優先度' },
+  { key: 'email', label: 'メールアドレス' },
+  { key: 'pattern', label: 'パターン' },
+  { key: 'contactPref', label: '連絡手段' },
+  { key: 'meetingStatus', label: '面談状況' },
+  { key: 'registrationStatus', label: '登録状況' },
+  { key: 'lineRegistered', label: 'LINE登録' },
+  { key: 'phoneNumber', label: '電話番号' },
+  { key: 'acquisitionSource', label: '流入経路' },
+  { key: 'facebookUrl', label: 'Facebook URL' },
+  { key: 'listAcquired', label: 'リスト取得' },
+  { key: 'matchingListUrl', label: 'マッチングリストURL' },
+  { key: 'contactOwner', label: 'コンタクト担当者' },
+  { key: 'sourceCreatedAt', label: '作成日 (YYYY-MM-DD HH:mm)' },
+  { key: 'marketingContactStatus', label: 'マーケティングコンタクトステータス' },
   { key: 'strengths', label: '強み' },
   { key: 'notes', label: 'メモ' },
   { key: 'tier', label: 'Tier (TIER1/TIER2)' },
   { key: 'tags', label: 'タグ(カンマ区切り可)' },
 ];
 
-type CsvRow = Record<string, string | undefined>;
+const MULTI_VALUE_FIELDS = new Set(['tags']);
+
+type HeaderInfo = {
+  id: string;
+  label: string;
+  raw: string;
+  index: number;
+};
+
+type CsvRow = string[];
 const BATCH_SIZE = 500;
 
 export default function CSVMapper() {
-  const [headers, setHeaders] = useState<string[]>([]);
+  const [headers, setHeaders] = useState<HeaderInfo[]>([]);
   const [rows, setRows] = useState<CsvRow[]>([]);
   const [allRows, setAllRows] = useState<CsvRow[]>([]);
   const [map, setMap] = useState<Record<string, string | string[]>>({});
   const [isImporting, setIsImporting] = useState(false);
 
+  const headerLookup = useMemo(() => {
+    return headers.reduce<Record<string, HeaderInfo>>((acc, header) => {
+      acc[header.id] = header;
+      return acc;
+    }, {});
+  }, [headers]);
+
   const onFile = useCallback((file: File) => {
     try {
-      Papa.parse<Record<string, string>>(file, {
-        header: true,
-        worker: true,
-        skipEmptyLines: true,
-        // transformHeader削除 - workerでは関数を渡せない
+      const canUseWorker = typeof window !== 'undefined' && typeof Worker !== 'undefined';
+
+      Papa.parse<(string | number | boolean | null)[]>(file, {
+        header: false,
+        worker: canUseWorker,
+        skipEmptyLines: 'greedy',
+        delimiter: '',
         complete: (res) => {
           try {
-            // 手動でヘッダと値を正規化
-            const rawFields = res.meta.fields ?? [];
-            const fields = rawFields.map((h) => (h ?? '').trim());
-            const rawData = (res.data ?? []).filter(Boolean);
-            
-            const data = rawData.map(row => {
-              const out: Record<string, string> = {};
-              fields.forEach((h) => {
-                const originalKey = rawFields[fields.indexOf(h)];
-                out[h] = (row[originalKey] ?? '').trim();
-              });
-              return out;
+            const parsedRows = (res.data ?? []).filter((row): row is (string | number | boolean | null)[] => Array.isArray(row));
+            if (parsedRows.length === 0) {
+              toast.error('CSV にヘッダ行が見つかりません');
+              return;
+            }
+
+            if (res.errors && res.errors.length > 0) {
+              const message = res.errors.map((err) => err.message).join('\n');
+              toast.warning(`CSV 解析で警告: ${message}`);
+            }
+
+            const rawHeaderRow = parsedRows[0] ?? [];
+            const dataRows = parsedRows.slice(1);
+
+            if (dataRows.length === 0) {
+              toast.error('CSV にデータ行がありません');
+              return;
+            }
+
+            const initialHeaders: HeaderInfo[] = rawHeaderRow.map((value, index) => {
+              const rawValue = value == null ? '' : String(value);
+              const trimmed = rawValue.trim();
+              const label = trimmed || `列${index + 1}`;
+              return {
+                id: `col_${index}`,
+                label,
+                raw: rawValue,
+                index,
+              };
             });
-            
-            const displayData = data.slice(0, 200);
-            
-            setHeaders(fields);
+
+            const maxColumns = dataRows.reduce((max, row) => Math.max(max, row.length), initialHeaders.length);
+            const headerInfos = [...initialHeaders];
+            for (let i = initialHeaders.length; i < maxColumns; i += 1) {
+              headerInfos.push({
+                id: `col_${i}`,
+                label: `列${i + 1}`,
+                raw: '',
+                index: i,
+              });
+            }
+
+            const normalizedRows = dataRows.map((row) => {
+              return headerInfos.map((_, index) => {
+                const cell = row[index];
+                if (cell == null) return '';
+                if (typeof cell === 'string') return cell.trim();
+                return String(cell).trim();
+              });
+            });
+
+            const displayData = normalizedRows.slice(0, 200);
+
+            setHeaders(headerInfos);
             setRows(displayData);
-            setAllRows(data);
-            toast.success(`CSVファイルを読み込みました（${data.length}行）`);
+            setAllRows(normalizedRows);
+            setMap({});
+            toast.success(`CSVファイルを読み込みました（${normalizedRows.length}行）`);
           } catch (e: unknown) {
             const errorMessage = e instanceof Error ? e.message : String(e);
             toast.error(`CSV データ処理で例外: ${errorMessage}`);
@@ -75,22 +145,55 @@ export default function CSVMapper() {
   }, []);
 
   const buildPayload = useCallback(() => {
-    return allRows.map((r) => {
+    return allRows.map((row) => {
       const obj: Record<string, unknown> = {};
       DB_FIELDS.forEach((f) => {
-        const m = map[f.key];
-        if (!m) return;
-        if (Array.isArray(m)) {
-          // 複数ヘッダ→結合
-          obj[f.key] = m.map((h) => (r[h] ?? '').trim()).filter(Boolean);
+        const mapping = map[f.key];
+        if (!mapping || (typeof mapping === 'string' && mapping.length === 0)) return;
+
+        const applySingleValue = (rawValue: string) => {
+          const value = rawValue.trim();
+          if (!value) return;
+
+          if (MULTI_VALUE_FIELDS.has(f.key)) {
+            const tags = value
+              .split(',')
+              .map((tag) => tag.trim())
+              .filter((tag) => tag.length > 0);
+            if (tags.length === 0) return;
+            const existing = Array.isArray(obj[f.key]) ? (obj[f.key] as string[]) : [];
+            obj[f.key] = Array.from(new Set([...existing, ...tags]));
+            return;
+          }
+
+          if (f.key === 'tier') {
+            const normalized = value.toUpperCase();
+            obj[f.key] = normalized === 'TIER1' || normalized === 'TIER2' ? normalized : value;
+            return;
+          }
+
+          obj[f.key] = value;
+        };
+
+        if (Array.isArray(mapping)) {
+          mapping.forEach((id) => {
+            const header = headerLookup[id];
+            if (!header) return;
+            const cell = row[header.index];
+            const value = cell == null ? '' : String(cell);
+            applySingleValue(value);
+          });
         } else {
-          const val = (r[m] ?? '').trim();
-          obj[f.key] = f.key === 'tags' ? val.split(',').map(s => s.trim()).filter(Boolean) : val;
+          const header = headerLookup[mapping];
+          if (!header) return;
+          const cell = row[header.index];
+          const value = cell == null ? '' : String(cell);
+          applySingleValue(value);
         }
       });
       return obj;
     });
-  }, [allRows, map]);
+  }, [allRows, headerLookup, map]);
 
   async function importInBatches(payload: Record<string, unknown>[]) {
     for (let i = 0; i < payload.length; i += BATCH_SIZE) {
@@ -99,6 +202,7 @@ export default function CSVMapper() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         cache: 'no-store',
+        credentials: 'include',
         body: JSON.stringify({ rows: chunk }),
       });
       if (!res.ok) {
@@ -115,7 +219,7 @@ export default function CSVMapper() {
       setIsImporting(true);
       await importInBatches(payload);
       toast.success('インポートが完了しました');
-      
+
       // リセット
       setHeaders([]);
       setRows([]);
@@ -132,8 +236,12 @@ export default function CSVMapper() {
   return (
     <div className="space-y-6">
       <Card>
-        <CardHeader>
-          <CardTitle>CSVファイルアップロード</CardTitle>
+        <CardHeader className="flex items-center justify-between">
+          <div>
+            <CardTitle>CSVファイルアップロード</CardTitle>
+            <CardDescription>UTF-8 の CSV / TSV ファイルを読み込めます</CardDescription>
+          </div>
+          <UploadCloud className="h-5 w-5 text-purple-600" />
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
@@ -147,7 +255,7 @@ export default function CSVMapper() {
                 className="mt-2"
               />
             </div>
-            
+
             {allRows.length > 0 && (
               <div className="text-sm text-muted-foreground">
                 {allRows.length}行のデータが読み込まれました（最初の200行を表示）
@@ -159,60 +267,107 @@ export default function CSVMapper() {
 
       {headers.length > 0 && (
         <Card>
-          <CardHeader>
-            <CardTitle>フィールドマッピング</CardTitle>
+          <CardHeader className="flex items-center justify-between">
+            <div>
+              <CardTitle>フィールドマッピング</CardTitle>
+              <CardDescription>取り込み先の列を選択してください</CardDescription>
+            </div>
+            <ListChecks className="h-5 w-5 text-purple-600" />
           </CardHeader>
           <CardContent>
             <div className="grid md:grid-cols-2 gap-4">
-              {DB_FIELDS.map(f => (
-                <div key={f.key} className="p-4 border rounded-lg space-y-3">
-                  <div className="font-medium">
-                    {f.label} → {Array.isArray(map[f.key]) ? (map[f.key] as string[]).join(",") : (map[f.key] || "未選択")}
-                  </div>
-                  
-                  <Select 
-                    value={Array.isArray(map[f.key]) ? "" : (map[f.key] as string) || ""} 
-                    onValueChange={value => setMap({ ...map, [f.key]: value })}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="（単一列を選択）" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="">（選択なし）</SelectItem>
-                      {headers.map(h => (
-                        <SelectItem key={h} value={h}>{h}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+              {DB_FIELDS.map((field) => {
+                const selected = map[field.key];
+                const selectedLabel = Array.isArray(selected)
+                  ? selected
+                      .map((id) => headerLookup[id]?.label ?? '（不明な列）')
+                      .join(', ')
+                  : (typeof selected === 'string' && selected.length > 0)
+                    ? headerLookup[selected]?.label ?? '（不明な列）'
+                    : '未選択';
 
-                  {f.key === "tags" && (
-                    <details className="mt-2">
-                      <summary className="cursor-pointer text-sm text-muted-foreground">
-                        タグに使う列を複数選択
-                      </summary>
-                      <div className="flex flex-wrap gap-2 mt-2">
-                        {headers.map(h => (
-                          <label key={h} className="text-sm flex items-center space-x-1">
-                            <input
-                              type="checkbox"
-                              checked={Array.isArray(map.tags) && (map.tags as string[]).includes(h)}
-                              onChange={e => {
-                                const cur = Array.isArray(map.tags) ? [...(map.tags as string[])] : [];
-                                if (e.target.checked) {
-                                  setMap({ ...map, tags: [...cur, h] });
-                                } else {
-                                  setMap({ ...map, tags: cur.filter(x => x !== h) });
-                                }
-                              }}
-                            />
-                            <span>{h}</span>
-                          </label>
-                        ))}
-                      </div>
-                    </details>
-                  )}
-                </div>
-              ))}
+                return (
+                  <div key={field.key} className="p-4 border rounded-lg space-y-3">
+                    <div className="font-medium">
+                      {field.label} → {selectedLabel}
+                    </div>
+
+                    <Select
+                      value={
+                        Array.isArray(selected)
+                          ? undefined
+                          : typeof selected === 'string' && selected.length > 0
+                            ? selected
+                            : undefined
+                      }
+                      onValueChange={(value) => {
+                        setMap((prev) => {
+                          if (value === '__CLEAR__') {
+                            const next = { ...prev };
+                            delete next[field.key];
+                            return next;
+                          }
+                          return { ...prev, [field.key]: value };
+                        });
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="（単一列を選択）" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__CLEAR__">（選択解除）</SelectItem>
+                        {headers.map((header) => {
+                          const trimmedRaw = header.raw.trim();
+                          return (
+                            <SelectItem key={header.id} value={header.id}>
+                              {header.label}
+                              {trimmedRaw.length > 0 && trimmedRaw !== header.label ? `（${header.raw}）` : ''}
+                            </SelectItem>
+                          );
+                        })}
+                      </SelectContent>
+                    </Select>
+
+                    {field.key === 'tags' && (
+                      <details className="mt-2">
+                        <summary className="cursor-pointer text-sm text-muted-foreground">
+                          タグに使う列を複数選択
+                        </summary>
+                        <div className="flex flex-wrap gap-2 mt-2">
+                          {headers.map((header) => {
+                            const isChecked = Array.isArray(map.tags) && (map.tags as string[]).includes(header.id);
+                            return (
+                              <label key={header.id} className="text-sm flex items-center space-x-1">
+                                <input
+                                  type="checkbox"
+                                  checked={isChecked}
+                                  onChange={(event) => {
+                                    setMap((prev) => {
+                                      const current = Array.isArray(prev.tags) ? [...(prev.tags as string[])] : [];
+                                      if (event.target.checked) {
+                                        if (current.includes(header.id)) return prev;
+                                        return { ...prev, tags: [...current, header.id] };
+                                      }
+                                      const nextTags = current.filter((id) => id !== header.id);
+                                      if (nextTags.length === 0) {
+                                        const next = { ...prev };
+                                        delete next.tags;
+                                        return next;
+                                      }
+                                      return { ...prev, tags: nextTags };
+                                    });
+                                  }}
+                                />
+                                <span>{header.label}</span>
+                              </label>
+                            );
+                          })}
+                        </div>
+                      </details>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </CardContent>
         </Card>
@@ -220,34 +375,48 @@ export default function CSVMapper() {
 
       {headers.length > 0 && (
         <Card>
-          <CardHeader>
-            <CardTitle>プレビュー</CardTitle>
+          <CardHeader className="flex items-center justify-between">
+            <div>
+              <CardTitle>プレビュー</CardTitle>
+              <CardDescription>最初の5行を表示しています</CardDescription>
+            </div>
+            <TableIcon className="h-5 w-5 text-purple-600" />
           </CardHeader>
           <CardContent>
             <div className="overflow-x-auto">
               <table className="w-full border-collapse border border-gray-300">
                 <thead>
                   <tr>
-                    {DB_FIELDS.filter(f => map[f.key]).map(f => (
-                      <th key={f.key} className="border border-gray-300 px-2 py-1 bg-gray-50 text-left">
-                        {f.label}
+                    {DB_FIELDS.filter((field) => map[field.key] && (!Array.isArray(map[field.key]) || (map[field.key] as string[]).length > 0)).map((field) => (
+                      <th key={field.key} className="border border-gray-300 px-2 py-1 bg-gray-50 text-left">
+                        {field.label}
                       </th>
                     ))}
                   </tr>
                 </thead>
                 <tbody>
-                  {rows.slice(0, 5).map((row, i) => (
-                    <tr key={i}>
-                      {DB_FIELDS.filter(f => map[f.key]).map(f => {
-                        const m = map[f.key];
-                        let value = "";
-                        if (Array.isArray(m)) {
-                          value = m.map(h => row[h]).filter(Boolean).join(", ");
-                        } else if (m) {
-                          value = row[m] || "";
+                  {rows.slice(0, 5).map((row, rowIndex) => (
+                    <tr key={rowIndex}>
+                      {DB_FIELDS.filter((field) => map[field.key] && (!Array.isArray(map[field.key]) || (map[field.key] as string[]).length > 0)).map((field) => {
+                        const mapping = map[field.key];
+                        let value = '';
+
+                        if (Array.isArray(mapping)) {
+                          value = mapping
+                            .map((id) => {
+                              const header = headerLookup[id];
+                              if (!header) return '';
+                              return row[header.index] ?? '';
+                            })
+                            .filter(Boolean)
+                            .join(', ');
+                        } else if (mapping) {
+                          const header = headerLookup[mapping];
+                          value = header ? row[header.index] ?? '' : '';
                         }
+
                         return (
-                          <td key={f.key} className="border border-gray-300 px-2 py-1 text-sm">
+                          <td key={field.key} className="border border-gray-300 px-2 py-1 text-sm">
                             {value}
                           </td>
                         );
@@ -273,7 +442,14 @@ export default function CSVMapper() {
             disabled={allRows.length === 0 || isImporting}
             className="w-full"
           >
-            {isImporting ? 'インポート中...' : `${allRows.length}件をインポート`}
+            {isImporting ? (
+              'インポート中...'
+            ) : (
+              <span className="flex items-center justify-center">
+                <UploadCloud className="mr-2 h-4 w-4" />
+                {allRows.length}件をインポート
+              </span>
+            )}
           </Button>
         </div>
       )}

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -1,11 +1,11 @@
 import { getSession } from '@/lib/session';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { Users, UserCheck } from 'lucide-react';
+import { FileSpreadsheet, Sparkles, Users, UserCheck } from 'lucide-react';
 
 export default async function MainNav() {
   const session = await getSession();
-  
+
   if (!session?.isLoggedIn) {
     return null;
   }
@@ -13,26 +13,48 @@ export default async function MainNav() {
   const userRole = session.role;
 
   return (
-    <nav className="w-full py-2 px-4 bg-purple-700/50">
-      <div className="mx-auto max-w-6xl flex items-center justify-end space-x-4">
-        {(userRole === 'ADMIN' || userRole === 'CS') && (
-          <>
-            {userRole === 'ADMIN' && (
-              <Link href="/admin/users">
-                <Button variant="ghost" size="sm" className="text-white hover:bg-purple-600/50">
-                  <Users className="mr-2 h-4 w-4" />
-                  ユーザー管理
+    <nav className="w-full py-3 px-4 flowgent-header">
+      <div className="mx-auto max-w-6xl flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <Link href="/" className="flex items-center space-x-2 text-white">
+          <Sparkles className="h-5 w-5" />
+          <span className="text-lg font-semibold">FlowGent</span>
+        </Link>
+
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Link href="/evangelists">
+            <Button variant="ghost" size="sm" className="text-white hover:bg-purple-600/60">
+              <Users className="mr-2 h-4 w-4" />
+              エヴァ一覧
+            </Button>
+          </Link>
+
+          <Link href="/evangelists/import">
+            <Button variant="ghost" size="sm" className="text-white hover:bg-purple-600/60">
+              <FileSpreadsheet className="mr-2 h-4 w-4" />
+              CSVインポート
+            </Button>
+          </Link>
+
+          {(userRole === 'ADMIN' || userRole === 'CS') && (
+            <>
+              <Link href="/admin/innovators">
+                <Button variant="ghost" size="sm" className="text-white hover:bg-purple-600/60">
+                  <UserCheck className="mr-2 h-4 w-4" />
+                  イノベータ管理
                 </Button>
               </Link>
-            )}
-            <Link href="/admin/innovators">
-              <Button variant="ghost" size="sm" className="text-white hover:bg-purple-600/50">
-                <UserCheck className="mr-2 h-4 w-4" />
-                イノベータ管理
-              </Button>
-            </Link>
-          </>
-        )}
+
+              {userRole === 'ADMIN' && (
+                <Link href="/admin/users">
+                  <Button variant="ghost" size="sm" className="text-white hover:bg-purple-600/60">
+                    <Users className="mr-2 h-4 w-4" />
+                    ユーザー管理
+                  </Button>
+                </Link>
+              )}
+            </>
+          )}
+        </div>
       </div>
     </nav>
   );

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "flowgent-card bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- extend the evangelist data model and import API to capture CRM priority, contact, and timeline fields while preferring record IDs over email-only upserts
- refresh the CSV import flow with richer mapping options, safer parsing defaults, credentialed uploads, and updated styling
- update dashboard navigation and cards so admin roles display correctly with clearer visual hierarchy on the purple theme

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e596ccdd388323be3e79f214f0c9fb