### PR TITLE
Fix: avoid empty strings in evangelist update payload

### DIFF
--- a/src/app/evangelists/[id]/page.tsx
+++ b/src/app/evangelists/[id]/page.tsx
@@ -202,10 +202,14 @@ export default function EvangelistDetailPage() {
 
   const handleSave = async () => {
     try {
+      const trimmedFirstName = editForm.firstName.trim()
+      const trimmedLastName = editForm.lastName.trim()
+      const trimmedEmail = editForm.email.trim()
+
       const payload = {
-        firstName: editForm.firstName,
-        lastName: editForm.lastName,
-        email: editForm.email,
+        ...(trimmedFirstName ? { firstName: trimmedFirstName } : {}),
+        ...(trimmedLastName ? { lastName: trimmedLastName } : {}),
+        ...(trimmedEmail ? { email: trimmedEmail } : {}),
         contactPreference: editForm.contactPreference ?? null,
         strength: editForm.strength ?? null,
         phase: editForm.phase,


### PR DESCRIPTION
## Summary
- import the EvangelistStrength enum and reuse it when filtering the dashboard IT evangelist metric
- prevent blank first name, last name, or email fields from being sent during evangelist updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5f2a0842c8323a08c3f7deda2547e