### PR TITLE
Refine evangelist import mapping and styling

### DIFF
--- a/src/app/api/evangelists/import/route.ts
+++ b/src/app/api/evangelists/import/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getIronSession } from 'iron-session';
 import { cookies } from 'next/headers';
+import type { PrismaPromise } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import type { SessionData } from '@/lib/session';
 
@@ -25,41 +26,36 @@ function requireRole(user: SessionData, roles: string[]) {
   }
 }
 
-// クライアント側 CSV マッピング後の行型（main 仕様）
+// クライアント側 CSV マッピング後の行型
 type ImportRow = {
-  // 識別系
-  recordId?: string;
-  email?: string;
-
-  // プロフィール/状態系
   firstName?: string;
   lastName?: string;
-  contactPref?: string;
-  supportPriority?: string;
-  pattern?: string;
-  meetingStatus?: string;
-  registrationStatus?: string;
-  lineRegistered?: string;
-  phoneNumber?: string;
-  acquisitionSource?: string;
-  facebookUrl?: string;
-  listAcquired?: string;
-  matchingListUrl?: string;
-  contactOwner?: string;
-  marketingContactStatus?: string;
-  sourceCreatedAt?: string; // CSVは文字列で来る想定
+  email?: string;
+  tier?: string;
   strengths?: string;
-  notes?: string;
-  tier?: string;            // "TIER1" | "TIER2" 以外は無視
-  tags?: string[] | string; // UIで配列/文字列どちらでも
+  pattern?: string;
+  registrationStatus?: string;
+  listAcquired?: string;
+  meetingStatus?: string;
 };
 
-function parseSourceCreatedAt(value?: string | null): Date | null {
-  if (!value) return null;
-  // 例: "2025/10/06 12:34" → "2025-10-06T12:34"
-  const normalized = value.replace(/\//g, '-').replace(' ', 'T');
-  const date = new Date(normalized);
-  return Number.isNaN(date.getTime()) ? null : date;
+type SanitizedRow = {
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  tier: string | null;
+  strengths: string | null;
+  pattern: string | null;
+  registrationStatus: string | null;
+  listAcquired: string | null;
+  meetingStatus: string | null;
+};
+
+function normalizeString(value?: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const asString = typeof value === 'string' ? value : String(value);
+  const trimmed = asString.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 function normalizeTier(input?: string | null): 'TIER1' | 'TIER2' | null {
@@ -79,100 +75,88 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'invalid' }, { status: 400 });
     }
 
-    const buildCreateData = (r: ImportRow) => ({
-      recordId: r.recordId || null,
-      firstName: r.firstName || null,
-      lastName: r.lastName || null,
-      email: r.email || null,
-      contactPref: r.contactPref || null,
-      supportPriority: r.supportPriority || null,
-      pattern: r.pattern || null,
-      meetingStatus: r.meetingStatus || null,
-      registrationStatus: r.registrationStatus || null,
-      lineRegistered: r.lineRegistered || null,
-      phoneNumber: r.phoneNumber || null,
-      acquisitionSource: r.acquisitionSource || null,
-      facebookUrl: r.facebookUrl || null,
-      listAcquired: r.listAcquired || null,
-      matchingListUrl: r.matchingListUrl || null,
-      contactOwner: r.contactOwner || null,
-      marketingContactStatus: r.marketingContactStatus || null,
-      sourceCreatedAt: parseSourceCreatedAt(r.sourceCreatedAt) || null,
-      strengths: r.strengths || null,
-      notes: r.notes || null,
+    const prelimRows = (rows as ImportRow[]).map((row, index) => ({
+      index,
+      firstName: normalizeString(row.firstName),
+      lastName: normalizeString(row.lastName),
+      email: normalizeString(row.email),
+      tier: normalizeString(row.tier),
+      strengths: normalizeString(row.strengths),
+      pattern: normalizeString(row.pattern),
+      registrationStatus: normalizeString(row.registrationStatus),
+      listAcquired: normalizeString(row.listAcquired),
+      meetingStatus: normalizeString(row.meetingStatus),
+    }));
+
+    const invalidRows = prelimRows
+      .filter((row) => !row.firstName || !row.lastName)
+      .map((row) => row.index + 1);
+
+    if (invalidRows.length > 0) {
+      return NextResponse.json(
+        { error: 'Missing required fields', rows: invalidRows },
+        { status: 400 },
+      );
+    }
+
+    const sanitizedRows: SanitizedRow[] = prelimRows.map((row) => ({
+      firstName: row.firstName!,
+      lastName: row.lastName!,
+      email: row.email,
+      tier: row.tier,
+      strengths: row.strengths,
+      pattern: row.pattern,
+      registrationStatus: row.registrationStatus,
+      listAcquired: row.listAcquired,
+      meetingStatus: row.meetingStatus,
+    }));
+
+    if (sanitizedRows.length === 0) {
+      return NextResponse.json({ error: 'No valid rows provided' }, { status: 400 });
+    }
+
+    const buildCreateData = (r: SanitizedRow) => ({
+      firstName: r.firstName,
+      lastName: r.lastName,
+      email: r.email ?? null,
+      strengths: r.strengths ?? null,
+      pattern: r.pattern ?? null,
+      registrationStatus: r.registrationStatus ?? null,
+      listAcquired: r.listAcquired ?? null,
+      meetingStatus: r.meetingStatus ?? null,
       tier: normalizeTier(r.tier) ?? 'TIER2',
-      tags: Array.isArray(r.tags)
-        ? JSON.stringify(r.tags)
-        : r.tags
-          ? JSON.stringify([r.tags])
-          : null,
-      // CS であれば自動割当、Admin は空で作る
-      assignedCsId: user.role === 'CS' ? user.userId : null,
+      assignedCsId: null,
     });
 
-    const buildUpdateData = (r: ImportRow) => ({
-      recordId: r.recordId || undefined,
-      firstName: r.firstName || undefined,
-      lastName: r.lastName || undefined,
-      email: r.email || undefined,
-      contactPref: r.contactPref || undefined,
-      supportPriority: r.supportPriority || undefined,
-      pattern: r.pattern || undefined,
-      meetingStatus: r.meetingStatus || undefined,
-      registrationStatus: r.registrationStatus || undefined,
-      lineRegistered: r.lineRegistered || undefined,
-      phoneNumber: r.phoneNumber || undefined,
-      acquisitionSource: r.acquisitionSource || undefined,
-      facebookUrl: r.facebookUrl || undefined,
-      listAcquired: r.listAcquired || undefined,
-      matchingListUrl: r.matchingListUrl || undefined,
-      contactOwner: r.contactOwner || undefined,
-      marketingContactStatus: r.marketingContactStatus || undefined,
-      sourceCreatedAt: parseSourceCreatedAt(r.sourceCreatedAt) || undefined,
-      strengths: r.strengths || undefined,
-      notes: r.notes || undefined,
-      tier: normalizeTier(r.tier) || undefined,
-      tags: Array.isArray(r.tags)
-        ? JSON.stringify(r.tags)
-        : r.tags
-          ? JSON.stringify([r.tags])
-          : undefined,
-      // 既存の assignedCsId は基本触らない（暗黙更新を避ける）
+    const buildUpdateData = (r: SanitizedRow) => ({
+      firstName: r.firstName,
+      lastName: r.lastName,
+      email: r.email ?? undefined,
+      strengths: r.strengths ?? undefined,
+      pattern: r.pattern ?? undefined,
+      registrationStatus: r.registrationStatus ?? undefined,
+      listAcquired: r.listAcquired ?? undefined,
+      meetingStatus: r.meetingStatus ?? undefined,
+      tier: normalizeTier(r.tier) ?? undefined,
     });
 
-    const operations = (rows as ImportRow[]).reduce((acc, r) => {
-      const createData = buildCreateData(r);
-      const updateData = buildUpdateData(r);
+    const operations: PrismaPromise<unknown>[] = sanitizedRows.map((row) => {
+      const createData = buildCreateData(row);
+      const updateData = buildUpdateData(row);
 
-      if (r.recordId) {
-        acc.push(
-          prisma.evangelist.upsert({
-            where: { recordId: r.recordId },
-            create: createData,
-            update: updateData,
-          }),
-        );
-        return acc;
+      if (row.email) {
+        return prisma.evangelist.upsert({
+          where: { email: row.email },
+          create: createData,
+          update: updateData,
+        });
       }
 
-      if (r.email) {
-        acc.push(
-          prisma.evangelist.upsert({
-            where: { email: r.email },
-            create: createData,
-            update: updateData,
-          }),
-        );
-        return acc;
-      }
-
-      // recordId / email が無い行は新規作成（重複は運用で回避）
-      acc.push(prisma.evangelist.create({ data: createData }));
-      return acc;
-    }, [] as Promise<unknown>[]);
+      return prisma.evangelist.create({ data: createData });
+    });
 
     await prisma.$transaction(operations);
-    return NextResponse.json({ ok: true, count: (rows as unknown[]).length });
+    return NextResponse.json({ ok: true, count: operations.length });
   } catch (error) {
     console.error('CSV import error:', error);
     if (error instanceof Error && error.message === 'Unauthorized') {

--- a/src/app/evangelists/[id]/page.tsx
+++ b/src/app/evangelists/[id]/page.tsx
@@ -202,10 +202,14 @@ export default function EvangelistDetailPage() {
 
   const handleSave = async () => {
     try {
+      const trimmedFirstName = editForm.firstName.trim()
+      const trimmedLastName = editForm.lastName.trim()
+      const trimmedEmail = editForm.email.trim()
+
       const payload = {
-        firstName: editForm.firstName,
-        lastName: editForm.lastName,
-        email: editForm.email,
+        ...(trimmedFirstName ? { firstName: trimmedFirstName } : {}),
+        ...(trimmedLastName ? { lastName: trimmedLastName } : {}),
+        ...(trimmedEmail ? { email: trimmedEmail } : {}),
         contactPreference: editForm.contactPreference ?? null,
         strength: editForm.strength ?? null,
         phase: editForm.phase,

--- a/src/app/evangelists/import/page.tsx
+++ b/src/app/evangelists/import/page.tsx
@@ -40,10 +40,10 @@ export default function EvangelistImportPage() {
             <div className="mt-4 p-4 bg-muted rounded-lg">
               <h4 className="font-medium mb-2">注意事項：</h4>
               <ul className="text-sm space-y-1 text-muted-foreground">
-                <li>• 同じメールアドレスのデータは上書きされます</li>
+                <li>• 同じメールアドレスのデータは上書きされます（メールアドレスが無い場合は新規作成）</li>
                 <li>• 最大200行まで一度にインポート可能です</li>
-                <li>• 必須フィールド：名、姓、メールアドレス</li>
-                <li>• タグは複数の列から選択可能です</li>
+                <li>• 必須フィールド：姓、名（メールアドレスは任意）</li>
+                <li>• 取り込み対象：強み・領域・登録有無・リスト提出有無・前回面談・Tier</li>
               </ul>
             </div>
           </CardContent>

--- a/src/app/evangelists/page.tsx
+++ b/src/app/evangelists/page.tsx
@@ -240,7 +240,7 @@ export default function EvangelistsPage() {
               <select
                 value={tierFilter}
                 onChange={(e) => setTierFilter(e.target.value as 'ALL' | 'TIER1' | 'TIER2')}
-                className="px-3 py-2 border border-input bg-background rounded-md"
+                className="px-3 py-2 border border-input bg-background text-slate-900 rounded-md"
               >
                 <option value="ALL">全てのTier</option>
                 <option value="TIER1">TIER1</option>
@@ -250,7 +250,7 @@ export default function EvangelistsPage() {
               <select
                 value={assignedCsFilter}
                 onChange={(e) => setAssignedCsFilter(e.target.value)}
-                className="px-3 py-2 border border-input bg-background rounded-md"
+                className="px-3 py-2 border border-input bg-background text-slate-900 rounded-md"
               >
                 <option value="">全ての担当CS</option>
                 {users.map((user) => (
@@ -263,7 +263,7 @@ export default function EvangelistsPage() {
               <select
                 value={staleFilter}
                 onChange={(e) => setStaleFilter(e.target.value)}
-                className="px-3 py-2 border border-input bg-background rounded-md"
+                className="px-3 py-2 border border-input bg-background text-slate-900 rounded-md"
               >
                 <option value="">フォロー期間</option>
                 <option value="7">7日以上未フォロー</option>

--- a/src/components/CSVMapper.tsx
+++ b/src/components/CSVMapper.tsx
@@ -11,31 +11,18 @@ import { toast } from 'sonner';
 import { UploadCloud, ListChecks, Table as TableIcon, Info, ShieldAlert } from 'lucide-react';
 
 const DB_FIELDS = [
-  { key: 'recordId', label: 'レコードID' },
-  { key: 'firstName', label: '名' },
-  { key: 'lastName', label: '姓' },
-  { key: 'supportPriority', label: 'サポート優先度' },
+  { key: 'lastName', label: '姓（必須）' },
+  { key: 'firstName', label: '名（必須）' },
   { key: 'email', label: 'メールアドレス' },
-  { key: 'pattern', label: 'パターン' },
-  { key: 'contactPref', label: '連絡手段' },
-  { key: 'meetingStatus', label: '面談状況' },
-  { key: 'registrationStatus', label: '登録状況' },
-  { key: 'lineRegistered', label: 'LINE登録' },
-  { key: 'phoneNumber', label: '電話番号' },
-  { key: 'acquisitionSource', label: '流入経路' },
-  { key: 'facebookUrl', label: 'Facebook URL' },
-  { key: 'listAcquired', label: 'リスト取得' },
-  { key: 'matchingListUrl', label: 'マッチングリストURL' },
-  { key: 'contactOwner', label: 'コンタクト担当者' },
-  { key: 'sourceCreatedAt', label: '作成日 (YYYY-MM-DD HH:mm)' },
-  { key: 'marketingContactStatus', label: 'マーケティングコンタクトステータス' },
-  { key: 'strengths', label: '強み' },
-  { key: 'notes', label: 'メモ' },
   { key: 'tier', label: 'Tier (TIER1/TIER2)' },
-  { key: 'tags', label: 'タグ(カンマ区切り可)' },
+  { key: 'strengths', label: '強み' },
+  { key: 'pattern', label: '領域' },
+  { key: 'registrationStatus', label: '登録有無' },
+  { key: 'listAcquired', label: 'リスト提出有無' },
+  { key: 'meetingStatus', label: '前回面談' },
 ] as const;
 
-const MULTI_VALUE_FIELDS = new Set(['tags']);
+const REQUIRED_FIELDS = ['lastName', 'firstName'] as const;
 
 type FieldKey = (typeof DB_FIELDS)[number]['key'];
 
@@ -50,16 +37,16 @@ type CsvRow = string[];
 const BATCH_SIZE = 500;
 
 const createEmptyMap = () =>
-  DB_FIELDS.reduce<Record<FieldKey, string | string[] | undefined>>((acc, field) => {
+  DB_FIELDS.reduce<Record<FieldKey, string | undefined>>((acc, field) => {
     acc[field.key] = undefined;
     return acc;
-  }, {} as Record<FieldKey, string | string[] | undefined>);
+  }, {} as Record<FieldKey, string | undefined>);
 
 export default function CSVMapper() {
   const [headers, setHeaders] = useState<HeaderInfo[]>([]);
   const [rows, setRows] = useState<CsvRow[]>([]);
   const [allRows, setAllRows] = useState<CsvRow[]>([]);
-  const [map, setMap] = useState<Record<FieldKey, string | string[] | undefined>>(() => createEmptyMap());
+  const [map, setMap] = useState<Record<FieldKey, string | undefined>>(() => createEmptyMap());
   const [isImporting, setIsImporting] = useState(false);
   const [lastImportCount, setLastImportCount] = useState<number | null>(null);
 
@@ -146,56 +133,53 @@ export default function CSVMapper() {
   }, []);
 
   const buildPayload = useCallback(() => {
-    return allRows.map((row) => {
-      const obj: Record<string, unknown> = {};
+    const invalidRows: number[] = [];
+    const records = allRows.map((row, index) => {
+      const record: Record<string, unknown> = {};
 
-      DB_FIELDS.forEach((f) => {
-        const mapping = map[f.key];
-        if (!mapping || (typeof mapping === 'string' && mapping.length === 0)) return;
+      DB_FIELDS.forEach((field) => {
+        const mapping = map[field.key];
+        if (!mapping) return;
 
-        const applySingleValue = (rawValue: string) => {
-          const value = rawValue.trim();
-          if (!value) return;
+        const header = headerLookup[mapping];
+        if (!header) return;
 
-          if (MULTI_VALUE_FIELDS.has(f.key)) {
-            const tags = value
-              .split(',')
-              .map((tag) => tag.trim())
-              .filter((tag) => tag.length > 0);
-            if (tags.length === 0) return;
-            const existing = Array.isArray(obj[f.key]) ? (obj[f.key] as string[]) : [];
-            obj[f.key] = Array.from(new Set([...existing, ...tags]));
-            return;
+        const raw = row[header.index];
+        const value = raw == null ? '' : String(raw).trim();
+
+        if (!value) {
+          if (REQUIRED_FIELDS.includes(field.key as (typeof REQUIRED_FIELDS)[number])) {
+            invalidRows.push(index + 1);
           }
-
-          if (f.key === 'tier') {
-            const normalized = value.toUpperCase();
-            obj[f.key] = normalized === 'TIER1' || normalized === 'TIER2' ? normalized : value;
-            return;
-          }
-
-          obj[f.key] = value;
-        };
-
-        if (Array.isArray(mapping)) {
-          mapping.forEach((id) => {
-            const header = headerLookup[id];
-            if (!header) return;
-            const cell = row[header.index];
-            const value = cell == null ? '' : String(cell);
-            applySingleValue(value);
-          });
-        } else {
-          const header = headerLookup[mapping];
-          if (!header) return;
-          const cell = row[header.index];
-          const value = cell == null ? '' : String(cell);
-          applySingleValue(value);
+          return;
         }
+
+        if (field.key === 'tier') {
+          const normalized = value.toUpperCase();
+          record[field.key] = normalized === 'TIER1' || normalized === 'TIER2' ? normalized : value;
+          return;
+        }
+
+        record[field.key] = value;
       });
 
-      return obj;
+      const hasAllRequired = REQUIRED_FIELDS.every((key) => {
+        const assignedHeader = map[key];
+        if (!assignedHeader) return false;
+        const header = headerLookup[assignedHeader];
+        if (!header) return false;
+        const raw = row[header.index];
+        return Boolean(raw != null && String(raw).trim());
+      });
+
+      if (!hasAllRequired && !invalidRows.includes(index + 1)) {
+        invalidRows.push(index + 1);
+      }
+
+      return record;
     });
+
+    return { records, invalidRows };
   }, [allRows, headerLookup, map]);
 
   async function importInBatches(payload: Record<string, unknown>[]) {
@@ -221,13 +205,17 @@ export default function CSVMapper() {
     try {
       if (!allRows.length) return toast.error('CSV データが空です');
 
-      const hasMapping = Object.values(map).some((v) =>
-        Array.isArray(v) ? v.length > 0 : Boolean(v && v.length > 0),
-      );
-      if (!hasMapping) return toast.error('取り込み先の列が選択されていません');
+      const requiredMapped = REQUIRED_FIELDS.every((key) => Boolean(map[key]));
+      if (!requiredMapped) return toast.error('姓と名の取り込み先を必ず選択してください');
 
-      const payload = buildPayload();
-      const meaningfulRows = payload.filter((row) =>
+      const { records, invalidRows } = buildPayload();
+      if (invalidRows.length > 0) {
+        const sample = invalidRows.slice(0, 5).join(', ');
+        const suffix = invalidRows.length > 5 ? ' など' : '';
+        return toast.error(`必須項目（姓・名）が空の行があります: ${sample}${suffix}`);
+      }
+
+      const meaningfulRows = records.filter((row) =>
         Object.values(row).some((value) => {
           if (Array.isArray(value)) return value.length > 0;
           if (value === null || value === undefined) return false;
@@ -258,9 +246,7 @@ export default function CSVMapper() {
     }
   };
 
-  const mappedFields = DB_FIELDS.filter(
-    (f) => map[f.key] && (!Array.isArray(map[f.key]) || (map[f.key] as string[]).length > 0),
-  );
+  const mappedFields = DB_FIELDS.filter((f) => Boolean(map[f.key]));
 
   return (
     <div className="space-y-8">
@@ -309,7 +295,7 @@ export default function CSVMapper() {
                 <CardTitle>取り込みフィールドのマッピング</CardTitle>
               </div>
               <CardDescription className="text-slate-600">
-                右側のプルダウンから CSV の列を選択してください。タグは複数列から統合できます。
+                右側のプルダウンから CSV の列を選択してください。姓と名は必須で、メールアドレスは任意項目です。
               </CardDescription>
             </div>
             <ListChecks className="h-6 w-6 text-purple-600" />
@@ -318,15 +304,11 @@ export default function CSVMapper() {
             <div className="grid gap-4 lg:grid-cols-2">
               {DB_FIELDS.map((field) => {
                 const selected = map[field.key];
-                const selectedLabel = Array.isArray(selected)
-                  ? selected.map((id) => headerLookup[id]?.label ?? '（不明な列）').join(', ')
-                  : typeof selected === 'string' && selected.length > 0
+                const selectedLabel = selected
                   ? headerLookup[selected]?.label ?? '（不明な列）'
                   : '未選択';
 
-                const isMapped = Array.isArray(selected)
-                  ? selected.length > 0
-                  : typeof selected === 'string' && selected.length > 0;
+                const isMapped = Boolean(selected);
 
                 return (
                   <div key={field.key} className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4 shadow-sm">
@@ -344,13 +326,7 @@ export default function CSVMapper() {
 
                     {/* 単一列マッピング（Radix Select: 空値禁止→未選択は undefined を使う） */}
                     <Select
-                      value={
-                        Array.isArray(selected)
-                          ? undefined
-                          : typeof selected === 'string' && selected.length > 0
-                          ? selected
-                          : undefined
-                      }
+                      value={selected || undefined}
                       onValueChange={(value) => {
                         setMap((prev) => {
                           if (value === '__CLEAR__') {
@@ -362,10 +338,10 @@ export default function CSVMapper() {
                         });
                       }}
                     >
-                      <SelectTrigger className="w-full bg-white">
+                      <SelectTrigger className="w-full bg-white text-slate-900">
                         <SelectValue placeholder="（単一列を選択）" />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="bg-white text-slate-900">
                         <SelectItem value="__CLEAR__">（選択解除）</SelectItem>
                         {headers.map((header) => (
                           <SelectItem key={header.id} value={header.id}>
@@ -377,46 +353,6 @@ export default function CSVMapper() {
                         ))}
                       </SelectContent>
                     </Select>
-
-                    {/* タグのみ複数列対応 */}
-                    {field.key === 'tags' && (
-                      <details className="mt-2">
-                        <summary className="cursor-pointer text-sm text-slate-600">タグに使う列を複数選択</summary>
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          {headers.map((header) => {
-                            const isChecked = Array.isArray(map.tags) && (map.tags as string[]).includes(header.id);
-                            return (
-                              <label
-                                key={header.id}
-                                className="flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-1 text-xs text-slate-600"
-                              >
-                                <input
-                                  type="checkbox"
-                                  checked={isChecked}
-                                  onChange={(event) => {
-                                    setMap((prev) => {
-                                      const current = Array.isArray(prev.tags) ? [...(prev.tags as string[])] : [];
-                                      if (event.target.checked) {
-                                        if (current.includes(header.id)) return prev;
-                                        return { ...prev, tags: [...current, header.id] };
-                                      }
-                                      const nextTags = current.filter((id) => id !== header.id);
-                                      if (nextTags.length === 0) {
-                                        const next = { ...prev };
-                                        delete next.tags;
-                                        return next;
-                                      }
-                                      return { ...prev, tags: nextTags };
-                                    });
-                                  }}
-                                />
-                                <span>{header.label}</span>
-                              </label>
-                            );
-                          })}
-                        </div>
-                      </details>
-                    )}
                   </div>
                 );
               })}
@@ -453,20 +389,8 @@ export default function CSVMapper() {
                     <tr key={rowIndex} className={rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'}>
                       {mappedFields.map((f) => {
                         const mapping = map[f.key];
-                        let value = '';
-                        if (Array.isArray(mapping)) {
-                          value = mapping
-                            .map((id) => {
-                              const header = headerLookup[id];
-                              if (!header) return '';
-                              return row[header.index] ?? '';
-                            })
-                            .filter(Boolean)
-                            .join(', ');
-                        } else if (mapping) {
-                          const header = headerLookup[mapping];
-                          value = header ? row[header.index] ?? '' : '';
-                        }
+                        const header = mapping ? headerLookup[mapping] : undefined;
+                        const value = header ? row[header.index] ?? '' : '';
 
                         return (
                           <td key={f.key} className="border border-slate-200 px-3 py-2 text-sm text-slate-700">


### PR DESCRIPTION
## Summary
- streamline the CSV mapper to only expose required evangelist fields and block rows that omit names
- update the evangelist import API to sanitize the reduced payload, avoid blank overwrites, and leave CS assignments unset
- refresh import instructions and dropdown styling so options remain legible across the app

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5f2a0842c8323a08c3f7deda2547e